### PR TITLE
Add pax extensions for long filename support.

### DIFF
--- a/src/Builder.xs
+++ b/src/Builder.xs
@@ -125,11 +125,12 @@ builder_new(klass, ...)
             char *key = SvPV_nolen(ST(i));
             SV *value = ST(i+1);
 
-            if (strcmp(key, "quiet")           == 0 && SvIV(value)) options |= B_BUILDER_QUIET;
-            if (strcmp(key, "ignore_errors")   == 0 && SvIV(value)) options |= B_BUILDER_IGNORE_ERRORS;
-            if (strcmp(key, "follow_symlinks") == 0 && SvIV(value)) options |= B_BUILDER_FOLLOW_SYMLINKS;
-            if (strcmp(key, "gnu_extensions")  == 0 && SvIV(value)) options |= B_BUILDER_GNU_EXTENSIONS;
-            if (strcmp(key, "block_factor")    == 0 && SvIV(value)) block_factor = SvIV(value);
+            if (strcmp(key, "quiet")            == 0 && SvIV(value)) options |= B_BUILDER_QUIET;
+            if (strcmp(key, "ignore_errors")    == 0 && SvIV(value)) options |= B_BUILDER_IGNORE_ERRORS;
+            if (strcmp(key, "follow_symlinks")  == 0 && SvIV(value)) options |= B_BUILDER_FOLLOW_SYMLINKS;
+            if (strcmp(key, "gnu_extensions")   == 0 && SvIV(value)) options |= B_BUILDER_GNU_EXTENSIONS;
+            if (strcmp(key, "posix_extensions") == 0 && SvIV(value)) options |= B_BUILDER_PAX_EXTENSIONS;
+            if (strcmp(key, "block_factor")     == 0 && SvIV(value)) block_factor = SvIV(value);
         }
 
         if ((builder = b_builder_new(block_factor)) == NULL) {

--- a/src/b_builder.h
+++ b/src/b_builder.h
@@ -25,7 +25,10 @@ enum b_builder_options {
     B_BUILDER_QUIET           = 1 << 0,
     B_BUILDER_IGNORE_ERRORS   = 1 << 1,
     B_BUILDER_FOLLOW_SYMLINKS = 1 << 2,
-    B_BUILDER_GNU_EXTENSIONS  = 1 << 3
+    B_BUILDER_GNU_EXTENSIONS  = 1 << 3,
+    B_BUILDER_PAX_EXTENSIONS  = 1 << 4,
+    B_BUILDER_EXTENSIONS_MASK = (B_BUILDER_GNU_EXTENSIONS |
+                                 B_BUILDER_PAX_EXTENSIONS)
 };
 
 typedef int (*b_lookup_service)(

--- a/src/b_file.h
+++ b/src/b_file.h
@@ -19,5 +19,6 @@
 
 off_t b_file_write_contents(b_buffer *buf, int file_fd, off_t file_size);
 off_t b_file_write_path_blocks(b_buffer *buf, b_string *path);
+off_t b_file_write_pax_path_blocks(b_buffer *buf, b_string *path);
 
 #endif /* _B_FILE_H */

--- a/src/b_header.h
+++ b/src/b_header.h
@@ -44,6 +44,7 @@
 #define B_HEADER_EMPTY_CHECKSUM  "\x20\x20\x20\x20\x20\x20\x20\x20"
 #define B_HEADER_LONGLINK_PATH   "././@LongLink"
 #define B_HEADER_LONGLINK_TYPE   'L'
+#define B_HEADER_PAX_TYPE        'x'
 
 #define B_HEADER_MODE_FORMAT      "%.7o"
 #define B_HEADER_UID_FORMAT       "%.7o"
@@ -99,6 +100,8 @@ b_header *       b_header_for_file(b_string *path, b_string *member_name, struct
 int              b_header_set_usernames(b_header *header, b_string *user, b_string *group);
 b_header_block * b_header_encode_block(b_header_block *block, b_header *header);
 b_header_block * b_header_encode_longlink_block(b_header_block *block, b_string *path);
+b_header_block * b_header_encode_pax_block(b_header_block *block, b_header *header, b_string *path);
+size_t           b_header_compute_pax_length(b_string *path);
 void             b_header_destroy(b_header *header);
 
 #endif /* _B_HEADER_H */

--- a/t/lib-Archive-Tar-Builder.t
+++ b/t/lib-Archive-Tar-Builder.t
@@ -21,7 +21,7 @@ use Errno;
 
 use Archive::Tar::Builder ();
 
-use Test::More tests => 58;
+use Test::More tests => 63;
 use Test::Exception;
 
 sub find_tar {
@@ -451,15 +451,15 @@ SKIP: {
 }
 
 # Test long filenames, symlinks
-{
+foreach my $ext (qw/gnu posix/) {
     my $tmpdir = File::Temp::tempdir( 'CLEANUP' => 1 );
-    my $path = "$tmpdir/" . ( 'foops/' x 30 );
+    my $path = "$tmpdir/" . ( 'foops/' x 60 );
 
     File::Path::mkpath($path) or die("Unable to create long path: $!");
 
     symlink( 'foo', "$tmpdir/bar" ) or die("Unable to symlink() $tmpdir/bar to foo: $!");
 
-    my $archive = Archive::Tar::Builder->new( 'gnu_extensions' => 1 );
+    my $archive = Archive::Tar::Builder->new( "${ext}_extensions" => 1 );
 
     my $err = Symbol::gensym();
 
@@ -799,6 +799,20 @@ for my $test_mode (
             $builder->archive_as( '/etc/hosts' => 'BLEH' x 60 );
         }
         '$builder->archive_as() will NOT croak() on long filenames when gnu_extensions is passed';
+    }
+
+    {
+        my $builder = Archive::Tar::Builder->new(
+            'quiet'            => 1,
+            'posix_extensions' => 1
+        );
+
+        $builder->set_handle($fh);
+
+        lives_ok {
+            $builder->archive_as( '/etc/hosts' => 'BLEH' x 60 );
+        }
+        '$builder->archive_as() will NOT croak() on long filenames when posix_extensions is passed';
     }
 
     close $fh;


### PR DESCRIPTION
The pax (POSIX) extensions are more portable than GNU LongLink headers.
Add a posix_extensions value that encodes these long filenames as pax
extended headers (type 'x').  Enhance the tests to test this code.

The code would need a small amount of refactoring to support both types of headers at the same time, so I avoided this for the moment.