### PR TITLE
Don't fail on EACCES when stat'ing file.

### DIFF
--- a/src/b_find.c
+++ b/src/b_find.c
@@ -260,7 +260,14 @@ int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_cal
         }
 
         if (b_stat(item->path, &item_st, flags) < 0) {
-            goto error_item;
+            if (err) {
+                b_error_set(err, B_ERROR_WARN, errno, "Unable to stat file", item->path);
+            }
+            if (errno == EACCES) {
+                goto cleanup_item;
+            } else {
+                goto error_item;
+            }
         }
 
         /*


### PR DESCRIPTION
If we recurse into a directory where we have read but not execute
permission, we can end up trying to stat a file but getting EACCES.  In
that case, print a warning and continue instead of aborting the tar
creation.