### PR TITLE
Support splice() and fix signal handling during read

### DIFF
--- a/src/b_buffer.h
+++ b/src/b_buffer.h
@@ -18,6 +18,7 @@
 
 typedef struct _b_buffer {
     int    fd;
+    int    is_pipe;
     size_t size;
     size_t unused;
     void * data;

--- a/src/b_file.c
+++ b/src/b_file.c
@@ -1,3 +1,6 @@
+#ifdef __linux__
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -6,6 +9,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "b_builder.h"
 #include "b_header.h"
@@ -49,49 +53,101 @@ error_io:
 off_t b_file_write_contents(b_buffer *buf, int file_fd, off_t file_size) {
     ssize_t rlen = 0, blocklen = 0;
     off_t total = 0, real_total = 0, max_read = 0;
+#ifdef __linux__
+    int emptied_buffer = 0, splice_total = 0;
+#endif
 
     do {
-        unsigned char *block;
-
         if (b_buffer_full(buf)) {
             if (b_buffer_flush(buf) < 0) {
                 goto error_io;
             }
-        }
-
-        if ((block = b_buffer_get_block(buf, b_buffer_unused(buf), &blocklen)) == NULL) {
-            goto error_io;
+            emptied_buffer = 1;
         }
 
         max_read = file_size - real_total;
-        if (max_read > blocklen) max_read = blocklen;
 
-        if ((rlen = read(file_fd, block, max_read)) < max_read) {
-            errno = EINVAL;
-
-            goto error_io;
+        if (max_read > INT_MAX) {
+             max_read = INT_MAX;
         }
+        else if (max_read == 0) {
+             break;
+        }
+#ifdef __linux__
+        /* Once we have cleared out the buffer we can
+           read the rest of the file with splice and
+           write out a tar padding */
+        if ( emptied_buffer && buf->is_pipe ) {
+            if ( rlen = splice(file_fd, NULL, buf->fd, NULL, max_read, 0) ){
+                if (rlen < 0) {
+                    goto splice_error_io;
+                }
+                splice_total += rlen;
+                total        += rlen;
+            }
+        } else {
+#endif
+            unsigned char *block;
 
-        total      += blocklen;
+            if ((block = b_buffer_get_block(buf, b_buffer_unused(buf), &blocklen)) == NULL) {
+                goto error_io;
+            }
+
+            if (max_read > blocklen) max_read = blocklen;
+
+
+           read_retry:
+            if ((rlen = read(file_fd, block, max_read)) < max_read) {
+                if (errno == EINTR) { goto read_retry; }
+
+                goto error_io;
+            }
+
+            total      += blocklen;
+            /*
+             * Reclaim any amount of bytes from the buffer that weren't used to
+             * store the chunk read() from the filesystem.
+             */
+            if (blocklen - rlen) {
+                total -= b_buffer_reclaim(buf, rlen, blocklen);
+            }
+#ifdef __linux__
+        }
+#endif
         real_total += rlen;
-
-        /*
-         * Reclaim any amount of bytes from the buffer that weren't used to
-         * store the chunk read() from the filesystem.
-         */
-        if (blocklen - rlen) {
-            total -= b_buffer_reclaim(buf, rlen, blocklen);
-        }
     } while (rlen > 0);
 
-    if (rlen < 0) {
-        errno = EINVAL;
-
-        goto error_io;
+#ifdef __linux__
+    if (splice_total && splice_total % B_BUFFER_BLOCK_SIZE != 0) {
+        // finished splice, now complete the block
+        // by writing out zeros to make tar happy
+        if ( (write(buf->fd, buf->data, B_BUFFER_BLOCK_SIZE - (splice_total % B_BUFFER_BLOCK_SIZE)))<0) {
+            goto error_io;
+        }
     }
+#endif
 
     return total;
 
 error_io:
+    if (!errno) { errno = EINVAL; }
     return -1;
+
+#ifdef __linux__
+splice_error_io:
+    if (splice_total && splice_total % B_BUFFER_BLOCK_SIZE != 0) {
+        int saved_errno = errno;
+         // finished splice, now complete the block
+        // by writing out zeros to make tar happy
+        if ( (write(buf->fd, buf->data, B_BUFFER_BLOCK_SIZE - (splice_total % B_BUFFER_BLOCK_SIZE)))<0) {
+            // We want to return the error
+            // from splice as it was the first error
+            // we encountered
+            errno = saved_errno;
+        }
+    }
+    return -1;
+#endif
+
+
 }


### PR DESCRIPTION
This is for information purposes only. (EINTR).  I'm not expecting to merge this since you are working on the more comprehensive change. 

b_file.c now supports using splice() on linux systems
 when available

 b_file.c's read() call now looks for EINTR (signal during
 read and will retry the read instead of failing)

 b_file.c now only sets EINVAL if there was an unknown error
 instead of supressing the known error

 Testing:
  Created multiple archives with 30G+ file sets and ensured
  that they properly extracted and splice() was being used on
  linux (verified via strace)

  Setup a process to send SIGSTOP/SIGCONT over and over again
  verified that the process no longer aborted with EINVAL when
  the read got EINTR
