### PR TITLE
Add support for long symlink destinations.

### DIFF
--- a/src/b_file.h
+++ b/src/b_file.h
@@ -19,6 +19,6 @@
 
 off_t b_file_write_contents(b_buffer *buf, int file_fd, off_t file_size);
 off_t b_file_write_path_blocks(b_buffer *buf, b_string *path);
-off_t b_file_write_pax_path_blocks(b_buffer *buf, b_string *path);
+off_t b_file_write_pax_path_blocks(b_buffer *buf, b_string *path, b_string *linkdest);
 
 #endif /* _B_FILE_H */

--- a/src/b_header.h
+++ b/src/b_header.h
@@ -44,6 +44,7 @@
 #define B_HEADER_EMPTY_CHECKSUM  "\x20\x20\x20\x20\x20\x20\x20\x20"
 #define B_HEADER_LONGLINK_PATH   "././@LongLink"
 #define B_HEADER_LONGLINK_TYPE   'L'
+#define B_HEADER_LONGDEST_TYPE   'K'
 #define B_HEADER_PAX_TYPE        'x'
 
 #define B_HEADER_MODE_FORMAT      "%.7o"
@@ -75,6 +76,7 @@ typedef struct _b_header {
     dev_t      minor;
     b_string * prefix;
     int        truncated;
+    int        truncated_link;
 } b_header;
 
 typedef struct _b_header_block {
@@ -99,9 +101,9 @@ typedef struct _b_header_block {
 b_header *       b_header_for_file(b_string *path, b_string *member_name, struct stat *st);
 int              b_header_set_usernames(b_header *header, b_string *user, b_string *group);
 b_header_block * b_header_encode_block(b_header_block *block, b_header *header);
-b_header_block * b_header_encode_longlink_block(b_header_block *block, b_string *path);
+b_header_block * b_header_encode_longlink_block(b_header_block *block, b_string *path, int type);
 b_header_block * b_header_encode_pax_block(b_header_block *block, b_header *header, b_string *path);
-size_t           b_header_compute_pax_length(b_string *path);
+size_t           b_header_compute_pax_length(b_string *path, const char *record);
 void             b_header_destroy(b_header *header);
 
 #endif /* _B_HEADER_H */


### PR DESCRIPTION
If a symlink destination is longer than 100 characters, it won't fit
into the tar header.  Archive::Tar::Builder used to just truncate these
entries.  Instead, have it encode them using either a GNU LongLink
header (type 'K') or a POSIX linkpath header record, as appropriate.

Note that GNU tar doesn't like it if you use a LongLink encoding when it
isn't required (i.e., for entries that fit normally in the header), so
we don't do that.  Making this work properly requires more code than the
lazy way.

Add a test to ensure that we encode the symlink destination properly as
well as the symlink's name itself.  This requires that we use tar -tvf,
but that appears to do the right thing on both GNU tar and BSD tar.
star appears to be broken in that case, but it was already broken in
other ways.