### PR TITLE
cPanel patches

### DIFF
--- a/src/b_buffer.c
+++ b/src/b_buffer.c
@@ -2,6 +2,11 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#ifdef __linux__
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <stdio.h>
+#endif
 #include "b_buffer.h"
 
 b_buffer *b_buffer_new(size_t factor) {
@@ -11,9 +16,10 @@ b_buffer *b_buffer_new(size_t factor) {
         goto error_malloc;
     }
 
-    buf->fd     = 0;
-    buf->size   = factor? factor * B_BUFFER_BLOCK_SIZE: B_BUFFER_DEFAULT_FACTOR * B_BUFFER_BLOCK_SIZE;
-    buf->unused = buf->size;
+    buf->fd         = 0;
+    buf->can_splice = 0;
+    buf->size       = factor? factor * B_BUFFER_BLOCK_SIZE: B_BUFFER_DEFAULT_FACTOR * B_BUFFER_BLOCK_SIZE;
+    buf->unused     = buf->size;
 
     if ((buf->data = malloc(buf->size)) == NULL) {
         goto error_malloc_buf;
@@ -24,9 +30,10 @@ b_buffer *b_buffer_new(size_t factor) {
     return buf;
 
 error_malloc_buf:
-    buf->data = NULL;
-    buf->fd   = 0;
-    buf->size = 0;
+    buf->data       = NULL;
+    buf->can_splice = 0;
+    buf->fd         = 0;
+    buf->size       = 0;
 
     free(buf);
 
@@ -41,9 +48,39 @@ int b_buffer_get_fd(b_buffer *buf) {
 }
 
 void b_buffer_set_fd(b_buffer *buf, int fd) {
+#ifdef __linux__
+    struct stat st;
+    char *release, *kernel, *major, *minor;
+    int kernel_v, major_v, minor_v;
+    struct utsname unameData;
+    int uname_ok;
+#endif
     if (buf == NULL) return;
 
-    buf->fd = fd;
+    buf->fd         = fd;
+    buf->can_splice = 0;
+#ifdef __linux__
+    if (fstat(fd, &st) == 0) {
+        if (S_ISFIFO(st.st_mode)) {
+            uname_ok = uname(&unameData);
+            if (uname_ok != -1) {
+                release = unameData.release;
+                kernel = strtok(release, ".");
+                major = strtok(NULL, ".");
+                minor = strtok(NULL, ".");
+                if (release && major && minor) {
+                    kernel_v = strtol(kernel,NULL,10);
+                    major_v = strtol(major,NULL,10);
+                    minor_v = strtol(minor,NULL,10);
+                    if (kernel_v >= 3 || (kernel_v == 2 && major_v == 6 && minor_v >= 31) ) {
+                        buf->can_splice = 1;
+                    }
+                }
+            }
+        }
+    }
+#endif
+    return;
 }
 
 size_t b_buffer_size(b_buffer *buf) {

--- a/src/b_buffer.h
+++ b/src/b_buffer.h
@@ -18,6 +18,7 @@
 
 typedef struct _b_buffer {
     int    fd;
+    int    can_splice;
     size_t size;
     size_t unused;
     void * data;

--- a/src/b_builder.c
+++ b/src/b_builder.c
@@ -131,11 +131,9 @@ static int encode_longlink(b_builder *builder, b_header_block *block, b_string *
     return 0;
 }
 
-int b_builder_write_file(b_builder *builder, b_string *path, b_string *member_name, struct stat *st) {
+int b_builder_write_file(b_builder *builder, b_string *path, b_string *member_name, struct stat *st, int fd) {
     b_buffer *buf = builder->buf;
     b_error *err  = builder->err;
-
-    int file_fd = 0;
 
     off_t wrlen = 0;
 
@@ -149,16 +147,6 @@ int b_builder_write_file(b_builder *builder, b_string *path, b_string *member_na
 
     if (err) {
         b_error_clear(err);
-    }
-
-    if ((st->st_mode & S_IFMT) == S_IFREG) {
-        if ((file_fd = open(path->str, O_RDONLY)) < 0) {
-            if (err) {
-                b_error_set(err, B_ERROR_WARN, errno, "Cannot open file", path);
-            }
-
-            goto error_open;
-        }
     }
 
     if ((header = b_header_for_file(path, member_name, st)) == NULL) {
@@ -206,8 +194,6 @@ int b_builder_write_file(b_builder *builder, b_string *path, b_string *member_na
             errno = ENAMETOOLONG;
 
             if (err) {
-                errno = ENAMETOOLONG;
-
                 b_error_set(err, B_ERROR_WARN, errno, "File name too long", member_name);
             }
 
@@ -272,8 +258,8 @@ int b_builder_write_file(b_builder *builder, b_string *path, b_string *member_na
     /*
      * Finally, end by writing the file contents.
      */
-    if (file_fd) {
-        if ((wrlen = b_file_write_contents(buf, file_fd, header->size)) < 0) {
+    if ((st->st_mode & S_IFMT) == S_IFREG && fd > 0) {
+        if ((wrlen = b_file_write_contents(buf, fd, header->size)) < 0) {
             if (err) {
                 b_error_set(err, B_ERROR_WARN, errno, "Cannot write file to archive", path);
             }
@@ -282,10 +268,6 @@ int b_builder_write_file(b_builder *builder, b_string *path, b_string *member_na
         }
 
         builder->total += wrlen;
-
-        close(file_fd);
-
-        file_fd = 0;
     }
 
     b_header_destroy(header);
@@ -302,11 +284,6 @@ error_lookup:
     b_header_destroy(header);
 
 error_header_for_file:
-    if (file_fd) {
-        close(file_fd);
-    }
-
-error_open:
     return -1;
 }
 

--- a/src/b_builder.h
+++ b/src/b_builder.h
@@ -103,7 +103,8 @@ int b_builder_write_file(
     b_builder *   builder,
     b_string *    path,
     b_string *    member_name,
-    struct stat * st
+    struct stat * st,
+    int           fd
 );
 
 void b_builder_destroy(b_builder *builder);

--- a/src/b_find.c
+++ b/src/b_find.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE 1
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -163,6 +165,14 @@ error_string_dup:
     return NULL;
 }
 
+static int clear_nonblock(int fd) {
+    int flags;
+
+    if ((flags = fcntl(fd, F_GETFL) < 0))
+        return -1;
+    return fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+}
+
 /*
  * callback() should return a 0 or 1; 0 to indicate that traversal at the current
  * level should halt, or 1 that it should continue.
@@ -171,12 +181,16 @@ int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_cal
     b_stack *dirs;
     b_dir *dir;
     struct stat st, item_st;
-    int res;
+    int fd = 0, res, oflags = O_RDONLY | O_NOFOLLOW | O_NONBLOCK;
 
     b_error *err = b_builder_get_error(builder);
 
     b_string *clean_path;
     b_string *clean_member_name;
+
+    if (flags & B_FIND_FOLLOW_SYMLINKS) {
+        oflags &= ~O_NOFOLLOW;
+    }
 
     if ((clean_path = b_path_clean(path)) == NULL) {
         goto error_path_clean;
@@ -201,7 +215,20 @@ int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_cal
      * callback, then do not bother with traversal code.  Otherwise, all code after
      * these guard clauses pertains to the case of 'path' being a directory.
      */
-    res = callback(builder, clean_path, clean_member_name, &st);
+    if ((st.st_mode & S_IFMT) == S_IFREG) {
+        if ((fd = open(clean_path->str, oflags)) < 0) {
+            goto error_open;
+        }
+        if (clear_nonblock(fd))
+            goto error_open;
+    }
+
+    res = callback(builder, clean_path, clean_member_name, &st, fd);
+
+    if (fd > 0) {
+        close(fd);
+        fd = 0;
+    }
 
     if (res == 0) {
         goto cleanup;
@@ -231,6 +258,7 @@ int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_cal
         b_dir_item *item;
         b_string *new_member_name;
         b_dir *cwd = b_stack_top(dirs);
+        int item_fd = 0;
 
         if (cwd == NULL) {
             break;
@@ -259,14 +287,44 @@ int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_cal
             goto cleanup_item;
         }
 
-        if (b_stat(item->path, &item_st, flags) < 0) {
-            if (err) {
-                b_error_set(err, B_ERROR_WARN, errno, "Unable to stat file", item->path);
-            }
-            if (errno == EACCES) {
-                goto cleanup_item;
+        if ((item_fd = open(item->path->str, oflags)) < 0) {
+            /*
+             * If O_NOFOLLOW is used (which is default) to open() the current
+             * item, then check for ELOOP; this condition will occur when
+             * attempting to open a symlink.  This means that we will need to
+             * simply use lstat() to retrieve information on the symlink inode
+             * itself.
+             *
+             * POSIX specifies ELOOP in this case, but FreeBSD uses EMLINK and
+             * NetBSD uses EFTYPE.  Work around this bugginess.
+             */
+#ifndef EFTYPE
+#define EFTYPE ELOOP
+#endif
+            if ((oflags & O_NOFOLLOW) && (errno == ELOOP || errno == EMLINK || errno == EFTYPE)) {
+                if (lstat(item->path->str, &item_st) < 0) {
+                    if (err) {
+                        b_error_set(err, B_ERROR_WARN, errno, "Cannot lstat() file", item->path);
+                    }
+
+                    goto cleanup_item;
+                }
             } else {
-                goto error_item;
+                if (err) {
+                    b_error_set(err, B_ERROR_WARN, errno, "Cannot open file", item->path);
+                }
+
+                goto cleanup_item;
+            }
+        } else {
+            if (clear_nonblock(fd))
+                goto cleanup_item;
+            if (fstat(item_fd, &item_st) < 0) {
+                if (err) {
+                    b_error_set(err, B_ERROR_WARN, errno, "Cannot fstat() file descriptor", item->path);
+                }
+
+                goto cleanup_item;
             }
         }
 
@@ -276,7 +334,7 @@ int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_cal
          */
         new_member_name = subst_member_name(clean_path, clean_member_name, item->path);
 
-        res = callback(builder, item->path, new_member_name? new_member_name: item->path, &item_st);
+        res = callback(builder, item->path, new_member_name? new_member_name: item->path, &item_st, item_fd);
 
         b_string_free(new_member_name);
 
@@ -313,11 +371,21 @@ int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_cal
         }
 
 cleanup_item:
+        if (item_fd > 0) {
+            close(item_fd);
+            item_fd = 0;
+        }
+
         b_dir_item_free(item);
 
         continue;
 
 error_item:
+        if (item_fd > 0) {
+            close(item_fd);
+            item_fd = 0;
+        }
+
         b_dir_item_free(item);
 
         goto error_cleanup;
@@ -334,6 +402,12 @@ error_cleanup:
 error_stack_push:
 error_dir_open:
 error_callback:
+    if (fd > 0) {
+        close(fd);
+        fd = 0;
+    }
+
+error_open:
 error_stat:
     b_stack_destroy(dirs);
 

--- a/src/b_find.h
+++ b/src/b_find.h
@@ -20,7 +20,7 @@
 #define B_FIND_FOLLOW_SYMLINKS (1 << 0)
 #define B_FIND_CALLBACK(c)     ((b_find_callback)c)
 
-typedef int (*b_find_callback)(b_builder *builder, b_string *path, b_string *member_name, struct stat *st);
+typedef int (*b_find_callback)(b_builder *builder, b_string *path, b_string *member_name, struct stat *st, int fd);
 
 int b_find(b_builder *builder, b_string *path, b_string *member_name, b_find_callback callback, int flags);
 


### PR DESCRIPTION
This branch contains the three patches that cPanel applies to Archive::Tar::Builder.  The first is a fixed version of an earlier upstream patch which was reverted, the second uses splice(2) on Linux if it's available and reliable, and the third improves error handling if we received EINTR.

If you'd prefer these be split out into multiple pull requests, I can do that as well.  I tried to fix up as much of the styling as I noticed, but it's possible I missed some.  If so, please let me know, and I'll squash in fixes.