### PR TITLE
Fix compilation on non-Linux.

### DIFF
--- a/src/b_file.c
+++ b/src/b_file.c
@@ -115,7 +115,9 @@ off_t b_file_write_contents(b_buffer *buf, int file_fd, off_t file_size) {
             if (b_buffer_flush(buf) < 0) {
                 goto error_io;
             }
+#ifdef __linux__
             emptied_buffer = 1;
+#endif
         }
 
         max_read = file_size - real_total;


### PR DESCRIPTION
A variable was defined to be only present on Linux for splice(2) usage, but it was referenced outside of an #ifdef.  Add an appropriate #ifdef to fix compilation on non-Linux systems.

I tested this by using cc -U__linux__; it now compiles cleanly.