### PR TITLE
Fix two size mismatch bugs

### DIFF
--- a/src/b_buffer.c
+++ b/src/b_buffer.c
@@ -125,7 +125,7 @@ off_t b_buffer_reclaim(b_buffer *buf, size_t used, size_t given) {
     return amount;
 }
 
-void *b_buffer_get_block(b_buffer *buf, size_t len, ssize_t *given) {
+void *b_buffer_get_block(b_buffer *buf, size_t len, off_t *given) {
     size_t offset;
     size_t padded_len = padded_size(len);
 

--- a/src/b_buffer.h
+++ b/src/b_buffer.h
@@ -31,7 +31,7 @@ size_t     b_buffer_size(b_buffer *buf);
 size_t     b_buffer_unused(b_buffer *buf);
 int        b_buffer_full(b_buffer *buf);
 off_t      b_buffer_reclaim(b_buffer *buf, size_t used, size_t given);
-void *     b_buffer_get_block(b_buffer *buf, size_t len, ssize_t *given);
+void *     b_buffer_get_block(b_buffer *buf, size_t len, off_t *given);
 ssize_t    b_buffer_flush(b_buffer *buf);
 void       b_buffer_reset(b_buffer *buf);
 void       b_buffer_destroy(b_buffer *buf);

--- a/src/b_file.c
+++ b/src/b_file.c
@@ -27,7 +27,7 @@
  */
 off_t b_file_write_path_blocks(b_buffer *buf, b_string *path) {
     size_t i, len;
-    ssize_t blocklen = 0;
+    off_t blocklen = 0;
     off_t total = 0;
 
     len = b_string_len(path);
@@ -55,7 +55,7 @@ error_io:
 
 off_t b_file_write_pax_path_blocks(b_buffer *buf, b_string *path, b_string *linkdest) {
     size_t i, len, full_len, link_full_len = 0, buflen, total_len;
-    ssize_t blocklen = 0;
+    off_t blocklen = 0;
     off_t total = 0;
     char *buffer = NULL;
 
@@ -104,8 +104,8 @@ error_mem:
 }
 
 off_t b_file_write_contents(b_buffer *buf, int file_fd, off_t file_size) {
-    ssize_t rlen = 0, blocklen = 0;
-    off_t total = 0, real_total = 0, max_read = 0;
+    ssize_t rlen = 0;
+    off_t blocklen = 0, total = 0, real_total = 0, max_read = 0;
 #ifdef __linux__
     int emptied_buffer = 0, splice_total = 0;
 #endif

--- a/src/b_header.c
+++ b/src/b_header.c
@@ -166,7 +166,7 @@ b_header_block *b_header_encode_pax_block(b_header_block *block, b_header *heade
 
 	b_header_encode_block(block, header);
 
-    snprintf(block->size, B_HEADER_SIZE_SIZE, B_HEADER_LONG_SIZE_FORMAT, pax_len);
+    snprintf(block->size, B_HEADER_SIZE_SIZE, B_HEADER_LONG_SIZE_FORMAT, (unsigned long long)pax_len);
 
 	memset(block->prefix, 0, sizeof(block->prefix));
 	snprintf(block->prefix, sizeof(block->prefix), "./PaxHeaders.%d", getpid());


### PR DESCRIPTION
This addresses one warning (which is probably breakage on big-endian systems) and one issue where we generate corrupt pax-style archives on 32-bit systems.  The latter can be easily reproduced by running the testsuite on a 32-bit system using the test introduced in f62b693bec362bc95d459f943b68b94b4effef7f.  The latter issue doesn't produce corrupt data on GNU-style archives.